### PR TITLE
Add backend service tests

### DIFF
--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import importlib
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+
+@pytest.fixture()
+def db_module(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    from app.core import config
+    importlib.reload(config)
+    from app.database import session as session_mod
+    importlib.reload(session_mod)
+    return session_mod
+
+@pytest.fixture()
+def db_session(db_module):
+    db = db_module.SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from app.services import auth_service
+from app.core import security
+from app.models.auth import LoginRequest, UserCreate
+from app.models.user import UserORM
+
+
+def test_authenticate_success(db_session):
+    db = db_session
+    user = UserORM(username="ali", hashed_password=security.get_password_hash("123"))
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    token = auth_service.authenticate(LoginRequest(username="ali", password="123"), db=db)
+    data = auth_service.decode_token(token.access_token)
+    assert data.sub == str(user.id)
+    assert token.message == "Login successful"
+
+
+def test_authenticate_fail(db_session):
+    db = db_session
+    user = UserORM(username="veli", hashed_password=security.get_password_hash("456"))
+    db.add(user)
+    db.commit()
+    token = auth_service.authenticate(LoginRequest(username="veli", password="000"), db=db)
+    assert token.message == "Invalid username or password"
+
+
+def test_admin_auto_create(db_session, monkeypatch):
+    db = db_session
+    monkeypatch.setenv("ADMIN_USER", "root")
+    monkeypatch.setenv("ADMIN_PASS", "secret")
+    token = auth_service.authenticate(LoginRequest(username="root", password="secret"), db=db)
+    created = db.query(UserORM).filter_by(username="root").first()
+    assert created is not None
+    data = auth_service.decode_token(token.access_token)
+    assert data.sub == str(created.id)

--- a/backend/app/tests/test_config.py
+++ b/backend/app/tests/test_config.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import importlib
+from pathlib import Path
+
+
+def test_settings_reads_external_key(tmp_path, monkeypatch):
+    key_file = tmp_path / "deep.key"
+    key_file.write_text("external")
+    monkeypatch.setenv("SECRET_KEY_FILE", str(key_file))
+    from app.core import config
+    importlib.reload(config)
+    assert config.settings.SECRET_KEY == "external"
+
+
+def test_origins_parsing(monkeypatch):
+    monkeypatch.setenv("ALLOWED_ORIGINS", "a.com , b.com")
+    from app.core import config
+    importlib.reload(config)
+    assert config.settings.origins == ["a.com", "b.com"]

--- a/backend/app/tests/test_database.py
+++ b/backend/app/tests/test_database.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+def test_get_db(db_module):
+    gen = db_module.get_db()
+    db = next(gen)
+    assert isinstance(db, Session)
+    assert db.execute(text("SELECT 1")).scalar() == 1
+    gen.close()

--- a/backend/app/tests/test_digital_signature.py
+++ b/backend/app/tests/test_digital_signature.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from security.encryption import digital_signature as ds
+
+
+def test_sign_verify_roundtrip():
+    priv, pub = ds.generate_key_pair()
+    msg = b"merhaba"
+    sig = ds.sign(msg, priv)
+    assert ds.verify(msg, sig, pub)
+
+
+def test_verify_fail_with_wrong_message():
+    priv, pub = ds.generate_key_pair()
+    sig = ds.sign(b"merhaba", priv)
+    assert not ds.verify(b"hata", sig, pub)

--- a/backend/app/tests/test_models.py
+++ b/backend/app/tests/test_models.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import pytest
+from app.services import model_service
+
+
+def test_register_and_inference(monkeypatch):
+    monkeypatch.setattr(model_service, "_models", {})
+    model_service.register_model("reverse", lambda x: x[::-1])
+    assert model_service.list_models() == ["reverse"]
+    assert model_service.run_inference("reverse", "abc") == "cba"
+    with pytest.raises(ValueError):
+        model_service.run_inference("none", "x")

--- a/backend/app/tests/test_users.py
+++ b/backend/app/tests/test_users.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+import pytest
+from fastapi import HTTPException
+from app.services import user_service
+from app.models.user import UserCreate
+
+
+def test_create_and_get_user(db_session):
+    db = db_session
+    user = user_service.create_user(db, UserCreate(username="ali", password="123"))
+    fetched = user_service.get_user(db, user.id)
+    assert fetched.username == "ali"
+
+
+def test_create_user_duplicate(db_session):
+    db = db_session
+    user_service.create_user(db, UserCreate(username="ali", password="123"))
+    with pytest.raises(HTTPException):
+        user_service.create_user(db, UserCreate(username="ali", password="456"))
+
+
+def test_list_users(db_session):
+    db = db_session
+    user_service.create_user(db, UserCreate(username="a", password="1"))
+    user_service.create_user(db, UserCreate(username="b", password="2"))
+    users = user_service.list_users(db)
+    assert len(users) == 2


### PR DESCRIPTION
## Summary
- expand backend test suite with database, auth, user and model checks
- include config parsing and digital signature tests
- provide fixtures for in-memory database sessions

## Testing
- `backend/venv/bin/python -m pytest backend/app/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68872c0d42888329a261e18cb2721402