### PR TITLE
gereksiz

### DIFF
--- a/backend/app/tests/test_critical.py
+++ b/backend/app/tests/test_critical.py
@@ -1,0 +1,48 @@
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE_DIR))
+sys.path.append(str(BASE_DIR / "app"))
+
+import pytest
+from fastapi.testclient import TestClient
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.main import create_app
+from app.core import security, rate_limiting
+from app.services import auth_service, user_service
+from app.models.user import UserCreate, UserORM
+
+
+def test_password_hash_and_verify():
+    hashed = security.get_password_hash("123")
+    assert security.verify_password("123", hashed)
+
+
+def test_token_create_and_decode():
+    token = security.create_access_token({"sub": "7"})
+    data = auth_service.decode_token(token)
+    assert data.sub == "7"
+
+
+def test_rate_limit(monkeypatch):
+    app = create_app()
+    client = TestClient(app)
+
+    monkeypatch.setattr(rate_limiting, "REQUEST_LIMIT", 2)
+    rate_limiting.visits.clear()
+
+    assert client.get("/health").status_code == 200
+    assert client.get("/health").status_code == 200
+    resp = client.get("/health")
+    assert resp.status_code == 429
+
+
+def test_duplicate_user_transaction(db_session):
+    db: Session = db_session
+    user_service.create_user(db, UserCreate(username="uniq", password="1"))
+    with pytest.raises(HTTPException):
+        user_service.create_user(db, UserCreate(username="uniq", password="2"))
+    assert db.query(UserORM).count() == 1

--- a/backend/app/tests/test_data_integrity.py
+++ b/backend/app/tests/test_data_integrity.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE_DIR))
+sys.path.append(str(BASE_DIR / "app"))
+
+from app.utils import helpers
+
+
+def test_json_roundtrip(tmp_path):
+    data = {"x": 1, "y": [1, 2]}
+    file = tmp_path / "data.json"
+    helpers.write_json(file, data)
+    assert helpers.read_json(file) == data
+
+
+def test_slugify():
+    assert helpers.slugify("Merhaba Dünya!") == "merhaba-d-nya"

--- a/backend/app/tests/test_logging_audit.py
+++ b/backend/app/tests/test_logging_audit.py
@@ -1,0 +1,58 @@
+import sys
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+sys.path.append(str(BASE_DIR))
+sys.path.append(str(BASE_DIR / "app"))
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.services import email_service
+from monitoring.logging import app_errors, audit_logs
+from app.core.logger import logger
+
+
+def test_email_logging(caplog):
+    caplog.set_level("INFO", logger=logger.name)
+    email_service.send_verification("a@test.com", "tok")
+    assert any("Verify a@test.com via token tok" in r.getMessage() for r in caplog.records)
+    caplog.clear()
+    email_service.send_reset("a@test.com", "tok")
+    assert any("Reset password for a@test.com via token tok" in r.getMessage() for r in caplog.records)
+
+
+def test_app_error_log(capsys):
+    app_errors.log_error("fail")
+    captured = capsys.readouterr().out.strip()
+    assert captured == "ERROR: fail"
+
+
+def test_audit_record_action():
+    audit_logs.LOGS.clear()
+    audit_logs.record_action("login")
+    assert audit_logs.LOGS == ["login"]
+
+
+def test_error_handler_logs(caplog):
+    app = create_app()
+
+    @app.get("/err")
+    def err_route():
+        raise HTTPException(status_code=418, detail="teapot")
+
+    client = TestClient(app)
+    caplog.set_level("ERROR", logger=logger.name)
+    response = client.get("/err")
+    assert response.status_code == 418
+    assert any("/err" in r.getMessage() and "418" in r.getMessage() for r in caplog.records)
+
+
+def test_request_logging(caplog):
+    app = create_app()
+    client = TestClient(app)
+    caplog.set_level("INFO", logger=logger.name)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert any("/health" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## Summary
- extend backend test coverage for logging and audit
- add data integrity tests for helper utilities
- test security and rate limiting logic

## Testing
- `pytest -q backend/app/tests`

------
https://chatgpt.com/codex/tasks/task_e_6887798573ec8329b6fae7def080e3f5