### PR TITLE
Add coverage script

### DIFF
--- a/backend/app/tests/run_coverage.py
+++ b/backend/app/tests/run_coverage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import subprocess
+import os
+
+ROOT = Path(__file__).resolve().parents[3]
+COVERAGE_DIR = ROOT / "coverage"
+COVERAGE_DIR.mkdir(exist_ok=True)
+ENV = os.environ.copy()
+ENV["PYTHONPATH"] = str(ROOT / "backend")
+
+cmd = [
+    "pytest",
+    "backend/app/tests",
+    "--import-mode=importlib",
+    "--cov=backend",
+    "--cov-report=term-missing",
+    f"--cov-report=xml:{COVERAGE_DIR / 'coverage.xml'}",
+    f"--cov-report=html:{COVERAGE_DIR / 'html'}",
+    "--cov-fail-under=60",
+]
+raise SystemExit(subprocess.call(cmd, cwd=ROOT, env=ENV))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ python-dotenv==1.1.1
 cryptography==44.0.1
 httpx==0.28.1
 PyJWT==2.10.1
+pytest-cov==6.2.1


### PR DESCRIPTION
## Summary
- add `run_coverage.py` to automate pytest coverage runs
- include `pytest-cov` in backend requirements

## Testing
- `python backend/app/tests/run_coverage.py`

------
https://chatgpt.com/codex/tasks/task_e_688783a93de883298eaa9ee828ed7a7a