### PR TITLE
Add backend test CI pipeline

### DIFF
--- a/backend/app/tests/ci_pipeline.yml
+++ b/backend/app/tests/ci_pipeline.yml
@@ -1,0 +1,30 @@
+name: Backend Testleri
+on:
+  push:
+    paths:
+      - 'backend/**'
+  pull_request:
+    paths:
+      - 'backend/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Kodu cek
+        uses: actions/checkout@v3
+      - name: Python kur
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Bagimliliklari yukle
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r backend/requirements.txt
+      - name: Testleri calistir
+        run: python backend/app/tests/run_coverage.py
+      - name: Raporu artefakt olarak yukle
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run backend tests with coverage

## Testing
- `python backend/app/tests/run_coverage.py`

------
https://chatgpt.com/codex/tasks/task_e_6887b4e424208329bd45542daa42e41a