### PR TITLE
Add typed Button component

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,21 +1,23 @@
-import { ReactNode, MouseEventHandler } from 'react';
+import { forwardRef, type ButtonHTMLAttributes } from 'react';
 
-type ButtonProps = {
-  children: ReactNode;
-  onClick?: MouseEventHandler<HTMLButtonElement>;
-  type?: 'button' | 'submit' | 'reset';
-  className?: string;
+export type ButtonVariant = 'primary' | 'secondary';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+}
+
+const variantClass: Record<ButtonVariant, string> = {
+  primary: 'button',
+  secondary: 'button button-secondary',
 };
 
-export default function Button({
-  children,
-  onClick,
-  type = 'button',
-  className,
-}: ButtonProps) {
-  return (
-    <button type={type} onClick={onClick} className={className}>
-      {children}
-    </button>
-  );
-}
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ variant = 'primary', className = '', ...rest }, ref) => {
+    const cls = `${variantClass[variant]} ${className}`.trim();
+    return <button ref={ref} className={cls} {...rest} />;
+  }
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/frontend/src/hooks/useToast.tsx
+++ b/frontend/src/hooks/useToast.tsx
@@ -1,5 +1,13 @@
 // Basit toast bildirimi yonetimi
-import { createContext, useState, type ReactNode, useMemo, useCallback } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  type ReactNode,
+  useCallback,
+  useMemo,
+} from 'react';
+
 interface Toast {
   id: number;
   message: string;
@@ -38,4 +46,8 @@ export function ToastProvider({ children }: { readonly children: ReactNode }) {
   );
 }
 
-// Remove useToast export from this file and move it to useToastHook.ts
+export const useToast = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error('ToastProvider gerekli');
+  return ctx;
+};

--- a/frontend/src/styles/main.css
+++ b/frontend/src/styles/main.css
@@ -43,6 +43,9 @@ body {
   background: var(--primary);
   color: #fff;
 }
+.button-secondary {
+  background: #6b7280;
+}
 .input {
   padding: 0.5rem;
   border: 1px solid #ccc;

--- a/tests/frontend/react-testing-library/Button.test.tsx
+++ b/tests/frontend/react-testing-library/Button.test.tsx
@@ -7,3 +7,9 @@ test('buton tiklaninca callback calisir', () => {
   fireEvent.click(screen.getByRole('button'));
   expect(onClick).toHaveBeenCalled();
 });
+
+test('variant sinifi uygulanir', () => {
+  render(<Button variant="secondary">Test</Button>);
+  const btn = screen.getByRole('button');
+  expect(btn.className).toContain('button-secondary');
+});


### PR DESCRIPTION
## Summary
- improve Button component with forwardRef, variant prop and TypeScript typings
- add secondary button style
- update useToast hook export
- extend button tests

## Testing
- `npm --prefix frontend test`

------
https://chatgpt.com/codex/tasks/task_e_6889a8c314a083299a3c699acb792b0b